### PR TITLE
Fix minor docker error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3
 WORKDIR /usr/src/app
 
 COPY ./run.sh .
-COPY ./conf/* .
+COPY ./conf/* ./
 RUN apt-get update &&\
     apt-get install -y expect 
 


### PR DESCRIPTION
```
Step 4/6 : COPY ./conf/* .
When using COPY with more than one source file, the destination must be a directory and end with a /
```

