### PR TITLE
Improve caching with separate installation step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,8 @@ RUN apt-get update &&\
     apt-get install -y expect &&\
     apt-get install -y jq
 
+COPY ./install_dependencies.sh .
+RUN chmod +x ./install_dependencies.sh &&\
+    sh install_dependencies.sh
+
 CMD [ "bash", "./run.sh" ]

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Get repository
+git clone https://github.com/aiven/python-fake-data-producer-for-apache-kafka.git
+pip install -r python-fake-data-producer-for-apache-kafka/requirements.txt
+pip install aiven-client

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,6 @@
 # Read env parameters
 . conf/env.conf
 
-# Get repository
-git clone https://github.com/aiven/python-fake-data-producer-for-apache-kafka.git
-pip install -r python-fake-data-producer-for-apache-kafka/requirements.txt
-pip install aiven-client
-
 # Get Hostname and Port
 HOSTNAME=$(avn --auth-token $TOKEN service get $SERVICE_NAME --project $PROJECT_NAME --json | jq -r '.components[] | select(.component=="kafka").host') 
 PORT=$(avn --auth-token $TOKEN service get $SERVICE_NAME --project $PROJECT_NAME --json | jq -r '.components[] | select(.component=="kafka").port')


### PR DESCRIPTION
# About this change - What it does

Run the installation steps for the fake data producer and Aiven CLI when building the image
to avoid re-installing these when re-running the container to send new data.

# Why this way

Noticed that the dependencies are re-installed if one wants to sent new data to the topic. Adding
a separate RUN step caches them improving startup time of the container.